### PR TITLE
Refactor/transit message format

### DIFF
--- a/common/include/Common/Core/Order.hpp
+++ b/common/include/Common/Core/Order.hpp
@@ -22,7 +22,8 @@ using Price = double;
 using OrderList = std::vector<Order>;
 
 /// @brief Available value for OrdStatus [39](https://www.onixs.biz/fix-dictionary/4.2/tagNum_39.html).
-enum OrderStatus {
+enum OrderStatus
+{
     New = 0,
     PartiallyFilled,
     Filled,

--- a/server/include/Server/Core/Core.hpp
+++ b/server/include/Server/Core/Core.hpp
@@ -28,13 +28,8 @@ class Core
 
         std::map<std::string, ProcessUnit<MarketContainer>> m_markets;
 
-        InUDP m_q_udp;
-        InputRouter m_q_router;
-        MarketEntry m_q_markets;
-        InOutNetwork m_q_tcp;
-
-        ProcessUnit<pip::InNetwork<net::tcp::in::Basic>> m_tcp_input;
-        ProcessUnit<pip::Router> m_router;
         ProcessUnit<pip::OutNetwork<net::tcp::out::Response>> m_tcp_output;
         ProcessUnit<pip::UDPOutNetwork> m_udp_output;
+        ProcessUnit<pip::Router> m_router;
+        ProcessUnit<pip::InNetwork<net::tcp::in::Basic>> m_tcp_input;
 };

--- a/server/include/Server/Core/Core.hpp
+++ b/server/include/Server/Core/Core.hpp
@@ -31,16 +31,10 @@ class Core
         InUDP m_q_udp;
         InputRouter m_q_router;
         MarketEntry m_q_markets;
-        InMarketData m_q_data;
-        InOutNetwork m_q_repdata;
         InOutNetwork m_q_tcp;
 
-        ProcessUnit<pip::InNetwork<net::tcp::in::Basic>> m_innet;
+        ProcessUnit<pip::InNetwork<net::tcp::in::Basic>> m_tcp_input;
         ProcessUnit<pip::Router> m_router;
-        ProcessUnit<pip::DataRefresh> m_data;
-
-        ProcessUnit<pip::OutNetwork<net::tcp::out::Response>> m_outnet;
-        ProcessUnit<pip::OutNetwork<net::tcp::out::SubResponse>> m_outdata;
-
-        ProcessUnit<pip::UDPOutNetwork> m_udp;
+        ProcessUnit<pip::OutNetwork<net::tcp::out::Response>> m_tcp_output;
+        ProcessUnit<pip::UDPOutNetwork> m_udp_output;
 };

--- a/server/include/Server/Core/InternalClient.hpp
+++ b/server/include/Server/Core/InternalClient.hpp
@@ -23,7 +23,7 @@ class InternalClient
 
         void disconnect();
         void shouldDisconnect(bool _disconnect);
-        [[nodiscard]] bool shouldDisconnect();
+        [[nodiscard]] bool shouldDisconnect() const;
 
         void setSeqNumber(size_t _seqnum);
         size_t nextSeqNumber();

--- a/server/include/Server/Core/MarketContainer.hpp
+++ b/server/include/Server/Core/MarketContainer.hpp
@@ -5,6 +5,7 @@
 #include "Server/Core/Pipeline/Naming.hpp"
 #include "Server/Core/Pipeline/OBEvent.hpp"
 #include "Server/Core/Pipeline/Notification.hpp"
+#include "Server/Core/Pipeline/DataRefresh.hpp"
 #include "Server/Core/Pipeline/ProcessUnit.hpp"
 
 class MarketContainer : public IProcessUnit
@@ -13,11 +14,7 @@ class MarketContainer : public IProcessUnit
         MarketContainer(const std::string &_name, InUDP &_udp, InOutNetwork &_tcp);
         virtual ~MarketContainer() = default;
 
-        [[nodiscard]] fix::MarketDataSnapshotFullRefresh refresh(const OrderBook::Subscription &_sub);
-        [[nodiscard]] fix::MarketDataIncrementalRefresh update(const OrderBook::Subscription &_sub);
-        void cache_flush();
-
-        [[nodiscard]] const std::string &getMarketName() const;
+        [[nodiscard]] const std::string &getMarketSymbol() const;
         [[nodiscard]] InMarket &getInput();
 
     protected:
@@ -27,11 +24,15 @@ class MarketContainer : public IProcessUnit
         const std::string m_name;
 
         OrderBook::EventQueue m_q_event;
-        InMarket m_q_action;
+        InMarket m_q_input;
 
+        InMarket m_q_order;
+        InMarket m_q_refresh;
+
+        ProcessUnit<pip::OBEvent> m_obevent;
         OrderBook m_ob;
 
         ProcessUnit<pip::Market> m_market;
-        ProcessUnit<pip::OBEvent> m_obevent;
         ProcessUnit<pip::Notification> m_notify;
+        ProcessUnit<pip::DataRefresh> m_data_refresh;
 };

--- a/server/include/Server/Core/MarketContainer.hpp
+++ b/server/include/Server/Core/MarketContainer.hpp
@@ -8,14 +8,14 @@
 #include "Server/Core/Pipeline/DataRefresh.hpp"
 #include "Server/Core/Pipeline/ProcessUnit.hpp"
 
-class MarketContainer : public IProcessUnit
+class MarketContainer : public IProcessUnit<Context<MarketInput>>
 {
     public:
         MarketContainer(const std::string &_name, InUDP &_udp, InOutNetwork &_tcp);
         virtual ~MarketContainer() = default;
 
         [[nodiscard]] const std::string &getMarketSymbol() const;
-        [[nodiscard]] InMarket &getInput();
+        [[nodiscard]] QueueInputType &getInput();
 
     protected:
         void runtime(std::stop_token _st);
@@ -24,10 +24,7 @@ class MarketContainer : public IProcessUnit
         const std::string m_name;
 
         OrderBook::EventQueue m_q_event;
-        InMarket m_q_input;
-
-        InMarket m_q_order;
-        InMarket m_q_refresh;
+        QueueInputType m_input;
 
         ProcessUnit<pip::OBEvent> m_obevent;
         OrderBook m_ob;

--- a/server/include/Server/Core/OrderBook.hpp
+++ b/server/include/Server/Core/OrderBook.hpp
@@ -70,7 +70,7 @@ class OrderBook
 
         [[nodiscard]] bool contain(OrderType _type, Price _price);
 
-        [[nodiscard]] std::string getSymbol() const;
+        [[nodiscard]] const std::string &getSymbol() const;
 
     protected:
         template<IsBook T>

--- a/server/include/Server/Core/OrderBook.hpp
+++ b/server/include/Server/Core/OrderBook.hpp
@@ -70,6 +70,8 @@ class OrderBook
 
         [[nodiscard]] bool contain(OrderType _type, Price _price);
 
+        [[nodiscard]] std::string getSymbol() const;
+
     protected:
         template<IsBook T>
         using OrderIdMap = std::unordered_map<OrderId, std::pair<typename T::iterator, OrderList::iterator>>;

--- a/server/include/Server/Core/Pipeline/DataRefresh.hpp
+++ b/server/include/Server/Core/Pipeline/DataRefresh.hpp
@@ -7,21 +7,21 @@
 
 namespace pip
 {
-    class DataRefresh : public IProcessUnit
+    class DataRefresh : public IProcessUnit<Context<MarketInput>>
     {
         public:
-            DataRefresh(std::map<std::string, ProcessUnit<MarketContainer>> &_markets, InMarketData &_input, InOutNetwork &_output);
+            DataRefresh(OrderBook &_ob, InOutNetwork &_output);
             virtual ~DataRefresh() = default;
 
         protected:
             void runtime(std::stop_token _st);
 
         private:
-            void process(Context<MarketDataInput> &_input);
+            void process(Context<MarketInput> &_input);
 
-            std::map<std::string, ProcessUnit<MarketContainer>> &m_markets;
+            OrderBook &m_ob;
 
-            InMarketData &m_input;
-            InOutNetwork &m_output;
+            InMarket m_input;
+            InOutNetwork &m_tcp_output;
     };
 }

--- a/server/include/Server/Core/Pipeline/DataRefresh.hpp
+++ b/server/include/Server/Core/Pipeline/DataRefresh.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Server/Core/Pipeline/Naming.hpp"
-#include "Server/Core/MarketContainer.hpp"
 #include "Server/Core/Pipeline/IProcessUnit.hpp"
 #include "Server/Core/Pipeline/ProcessUnit.hpp"
 
@@ -13,6 +12,8 @@ namespace pip
             DataRefresh(OrderBook &_ob, InOutNetwork &_output);
             virtual ~DataRefresh() = default;
 
+            [[nodiscard]] QueueInputType &getInput();
+
         protected:
             void runtime(std::stop_token _st);
 
@@ -21,7 +22,7 @@ namespace pip
 
             OrderBook &m_ob;
 
-            InMarket m_input;
+            QueueInputType m_input;
             InOutNetwork &m_tcp_output;
     };
 }

--- a/server/include/Server/Core/Pipeline/DataRefresh.hpp
+++ b/server/include/Server/Core/Pipeline/DataRefresh.hpp
@@ -17,7 +17,7 @@ namespace pip
             void runtime(std::stop_token _st);
 
         private:
-            void process(MarketDataInput &_input);
+            void process(Context<MarketDataInput> &_input);
 
             std::map<std::string, ProcessUnit<MarketContainer>> &m_markets;
 

--- a/server/include/Server/Core/Pipeline/IProcessUnit.hpp
+++ b/server/include/Server/Core/Pipeline/IProcessUnit.hpp
@@ -2,8 +2,17 @@
 
 #include <stop_token>
 
-class IProcessUnit
+class IProcessUnitBase
 {
     protected:
         virtual void runtime(std::stop_token _st) = 0;
+};
+
+template<class T>
+class IProcessUnit : IProcessUnitBase
+{
+    public:
+        using InputType = ts::Queue<T>;
+
+        InputType &getInput();
 };

--- a/server/include/Server/Core/Pipeline/IProcessUnit.hpp
+++ b/server/include/Server/Core/Pipeline/IProcessUnit.hpp
@@ -12,7 +12,8 @@ template<class T>
 class IProcessUnit : IProcessUnitBase
 {
     public:
-        using InputType = ts::Queue<T>;
+        using InputType = T;
+        using QueueInputType = ts::Queue<T>;
 
         InputType &getInput();
 };

--- a/server/include/Server/Core/Pipeline/InNetwork.hpp
+++ b/server/include/Server/Core/Pipeline/InNetwork.hpp
@@ -18,7 +18,7 @@ namespace pip
     /// @tparam __T is the format socket are stored in the vector referenced.
     template<class Func>
     requires IsProcessor<Func, const ClientStore::Client &, InputRouter &, InOutNetwork &>
-    class InNetwork : public IProcessUnit
+    class InNetwork : public IProcessUnitBase
     {
         public:
             /// @brief Setup the network input and start listening on _port

--- a/server/include/Server/Core/Pipeline/InNetwork.hpp
+++ b/server/include/Server/Core/Pipeline/InNetwork.hpp
@@ -17,7 +17,7 @@ namespace pip
     /// @tparam _T is function to process when an action is needed on a socket.
     /// @tparam __T is the format socket are stored in the vector referenced.
     template<class Func>
-    requires IsProcessor<Func, ClientStore::Client, InputRouter &, InOutNetwork &>
+    requires IsProcessor<Func, const ClientStore::Client &, InputRouter &, InOutNetwork &>
     class InNetwork : public IProcessUnit
     {
         public:

--- a/server/include/Server/Core/Pipeline/InNetwork.inl
+++ b/server/include/Server/Core/Pipeline/InNetwork.inl
@@ -6,7 +6,7 @@
 namespace pip
 {
     template<class Func>
-    requires IsProcessor<Func, ClientStore::Client, InputRouter &, InOutNetwork &>
+    requires IsProcessor<Func, const ClientStore::Client &, InputRouter &, InOutNetwork &>
     InNetwork<Func>::InNetwork(InputRouter &_output, InOutNetwork &_error, uint32_t _port)
         : m_output(_output), m_error(_error), m_acceptor(), m_selector()
     {
@@ -17,7 +17,7 @@ namespace pip
     }
 
     template<class Func>
-    requires IsProcessor<Func, ClientStore::Client, InputRouter &, InOutNetwork &>
+    requires IsProcessor<Func, const ClientStore::Client &, InputRouter &, InOutNetwork &>
     void InNetwork<Func>::runtime(std::stop_token _st)
     {
         ClientStore::ClientSocket accept = nullptr;

--- a/server/include/Server/Core/Pipeline/Market.hpp
+++ b/server/include/Server/Core/Pipeline/Market.hpp
@@ -18,10 +18,10 @@ namespace pip
             /// @param _ob OrderBook reference.
             /// @param _input Input data queue.
             /// @param _output Output data queue.
-            Market(OrderBook &_ob, InMarket &_input, InOutNetwork &_output);
+            Market(OrderBook &_ob, InOutNetwork &_output);
             virtual ~Market() = default;
 
-            [[nodiscard]] InputType &getInput();
+            [[nodiscard]] QueueInputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
@@ -37,7 +37,7 @@ namespace pip
 
             const std::string m_name;
 
-            InMarket m_input;        ///< Intput data queue.
+            QueueInputType m_input;        ///< Intput data queue.
             InOutNetwork &m_tcp_output;          ///< Output data queue.
 
             ThreadPool<TS_SIZE_OB> m_tp;    ///< Thread pool to run async processing.

--- a/server/include/Server/Core/Pipeline/Market.hpp
+++ b/server/include/Server/Core/Pipeline/Market.hpp
@@ -27,11 +27,11 @@ namespace pip
         private:
             /// @brief Apply the action received by the pip::Action pipeline on the OrderBook.
             /// @param _data Data to build and run action on the OrderBook.
-            void process(MarketInput &_data);
+            void process(Context<MarketInput> &_data);
 
-            bool runAdd(const MarketInput &_data);
-            bool runModify(const MarketInput &_data);
-            bool runCancel(const MarketInput &_data);
+            bool runAdd(const Context<MarketInput> &_data);
+            bool runModify(const Context<MarketInput> &_data);
+            bool runCancel(const Context<MarketInput> &_data);
 
             const std::string m_name;
 

--- a/server/include/Server/Core/Pipeline/Market.hpp
+++ b/server/include/Server/Core/Pipeline/Market.hpp
@@ -11,7 +11,7 @@
 namespace pip
 {
     /// @brief Pipeline managing the OrderBook.
-    class Market : public IProcessUnit
+    class Market : public IProcessUnit<Context<MarketInput>>
     {
         public:
             /// @brief Construct the pipeline.
@@ -20,6 +20,8 @@ namespace pip
             /// @param _output Output data queue.
             Market(OrderBook &_ob, InMarket &_input, InOutNetwork &_output);
             virtual ~Market() = default;
+
+            [[nodiscard]] InputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
@@ -35,8 +37,8 @@ namespace pip
 
             const std::string m_name;
 
-            InMarket &m_input;        ///< Intput data queue.
-            InOutNetwork &m_output;          ///< Output data queue.
+            InMarket m_input;        ///< Intput data queue.
+            InOutNetwork &m_tcp_output;          ///< Output data queue.
 
             ThreadPool<TS_SIZE_OB> m_tp;    ///< Thread pool to run async processing.
 

--- a/server/include/Server/Core/Pipeline/Naming.hpp
+++ b/server/include/Server/Core/Pipeline/Naming.hpp
@@ -15,6 +15,7 @@ struct Context : T
     Context(const Context<T> &_data);
     template<class ...Ts>
     Context(const ClientStore::Client &_client, std::chrono::system_clock::time_point _time, Ts &&..._args);
+    ~Context() = default;
 
     ClientStore::Client Client = nullptr;                      ///< Sender client information.
     std::chrono::system_clock::time_point ReceiveTime;
@@ -29,6 +30,7 @@ struct RouterInput
     RouterInput(RouterInput &&_data) noexcept;
     RouterInput(const RouterInput &_data);
     RouterInput(const fix::Serializer::AnonMessage &&_message);
+    virtual ~RouterInput() = default;
 
     RouterInput &operator=(RouterInput &&_data) noexcept;
 
@@ -51,6 +53,7 @@ struct MarketInput
     MarketInput() = default;
     MarketInput(MarketInput &&_data) noexcept;
     MarketInput(const MarketInput &_data);
+    virtual ~MarketInput();
 
     enum Type
     {
@@ -60,10 +63,10 @@ struct MarketInput
 
     MarketInput &operator=(MarketInput &&_data) noexcept;
 
-    Type type;
+    Type type = Order;
 
     union {
-        OrderBook::Data OrderData;                        ///< Action to apply to the OrderBook.
+        OrderBook::Data OrderData{};                        ///< Action to apply to the OrderBook.
         MarketRefreshInputData RefreshData;
     };
 };
@@ -75,6 +78,7 @@ struct OutNetworkInput
     OutNetworkInput(OutNetworkInput &&_data) noexcept;
     OutNetworkInput(const OutNetworkInput &_data);
     OutNetworkInput(const fix::Message &&_msg) noexcept;
+    virtual ~OutNetworkInput() = default;
 
     OutNetworkInput &operator=(OutNetworkInput &&_data) noexcept;
 

--- a/server/include/Server/Core/Pipeline/Naming.hpp
+++ b/server/include/Server/Core/Pipeline/Naming.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <variant>
+
 #include "Common/Message/Fix.hpp"
 #include "Common/Message/Serializer.hpp"
 #include "Common/Thread/Queue.hpp"
@@ -27,12 +29,12 @@ struct Context : T
 struct RouterInput
 {
     RouterInput() = default;
-    RouterInput(RouterInput &&_data) noexcept;
-    RouterInput(const RouterInput &_data);
+    RouterInput(RouterInput &&_data) noexcept = default;
+    RouterInput(const RouterInput &_data) = default;
     RouterInput(const fix::Serializer::AnonMessage &&_message);
     virtual ~RouterInput() = default;
 
-    RouterInput &operator=(RouterInput &&_data) noexcept;
+    RouterInput &operator=(RouterInput &&_data) noexcept = default;
 
     fix::Serializer::AnonMessage Message{};     ///< Undefined message data.
 };
@@ -51,9 +53,9 @@ struct MarketRefreshInputData
 struct MarketInput
 {
     MarketInput() = default;
-    MarketInput(MarketInput &&_data) noexcept;
-    MarketInput(const MarketInput &_data);
-    virtual ~MarketInput();
+    MarketInput(MarketInput &&_data) noexcept = default;
+    MarketInput(const MarketInput &_data) = default;
+    virtual ~MarketInput() = default;
 
     enum Type
     {
@@ -61,26 +63,23 @@ struct MarketInput
         Refresh
     };
 
-    MarketInput &operator=(MarketInput &&_data) noexcept;
+    MarketInput &operator=(MarketInput &&_data) noexcept = default;
 
     Type type = Order;
 
-    union {
-        OrderBook::Data OrderData{};                        ///< Action to apply to the OrderBook.
-        MarketRefreshInputData RefreshData;
-    };
+    std::variant<OrderBook::Data, MarketRefreshInputData> Data;
 };
 
 /// @brief Data transfered from the pip::Market pipeline to the pip::OutNetwork pipeline
 struct OutNetworkInput
 {
     OutNetworkInput() = default;
-    OutNetworkInput(OutNetworkInput &&_data) noexcept;
-    OutNetworkInput(const OutNetworkInput &_data);
+    OutNetworkInput(OutNetworkInput &&_data) noexcept = default;
+    OutNetworkInput(const OutNetworkInput &_data) = default;
     OutNetworkInput(const fix::Message &&_msg) noexcept;
     virtual ~OutNetworkInput() = default;
 
-    OutNetworkInput &operator=(OutNetworkInput &&_data) noexcept;
+    OutNetworkInput &operator=(OutNetworkInput &&_data) noexcept = default;
 
     fix::Message Message{};                     ///< Final message send to the client.
 };

--- a/server/include/Server/Core/Pipeline/Naming.inl
+++ b/server/include/Server/Core/Pipeline/Naming.inl
@@ -1,0 +1,31 @@
+#include "Server/Core/Pipeline/Naming.hpp"
+
+template<class T>
+Context<T>::Context(const Context<T> &&_data) noexcept
+    : T(std::move(_data)), Client(std::move(_data.Client)), ReceiveTime(std::move(_data.ReceiveTime))
+{
+}
+
+template<class T>
+Context<T>::Context(const Context<T> &_data)
+    : T(_data), Client(_data.Client), ReceiveTime(_data.ReceiveTime)
+{
+}
+
+template<class T>
+template<class ...Ts>
+Context<T>::Context(const ClientStore::Client &_client, std::chrono::system_clock::time_point _time, Ts &&..._args)
+    : T(std::forward<Ts>(_args)...), Client(_client), ReceiveTime(_time)
+{
+}
+
+template<class T>
+Context<T> &Context<T>::operator=(Context<T> &&_data) noexcept
+{
+    if (this != &_data) {
+        Client = std::move(_data.Client);
+        ReceiveTime = std::move(_data.ReceiveTime);
+        T::operator=(std::move(_data));
+    }
+    return *this;
+}

--- a/server/include/Server/Core/Pipeline/Notification.hpp
+++ b/server/include/Server/Core/Pipeline/Notification.hpp
@@ -14,7 +14,7 @@
 
 namespace pip
 {
-    class Notification : public IProcessUnit
+    class Notification : public IProcessUnitBase
     {
         public:
             Notification(const std::string &_name, OrderBook &_ob, InOutNetwork &_tcp);

--- a/server/include/Server/Core/Pipeline/Notification.hpp
+++ b/server/include/Server/Core/Pipeline/Notification.hpp
@@ -17,7 +17,7 @@ namespace pip
     class Notification : public IProcessUnitBase
     {
         public:
-            Notification(const std::string &_name, OrderBook &_ob, InOutNetwork &_tcp);
+            Notification(OrderBook &_ob, InOutNetwork &_tcp);
             virtual ~Notification() = default;
 
         protected:

--- a/server/include/Server/Core/Pipeline/OBEvent.hpp
+++ b/server/include/Server/Core/Pipeline/OBEvent.hpp
@@ -12,11 +12,13 @@
 
 namespace pip
 {
-    class OBEvent : public IProcessUnit
+    class OBEvent : public IProcessUnit<OrderBook::Event>
     {
         public:
-            OBEvent(const std::string &_name, OrderBook::EventQueue &_input, InUDP &_udp, InOutNetwork &_tcp);
+            OBEvent(const std::string &_name, InUDP &_udp, InOutNetwork &_tcp);
             virtual ~OBEvent() = default;
+
+            [[nodiscard]] InputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
@@ -28,11 +30,10 @@ namespace pip
         private:
             const std::string m_name;
 
-            OrderBook::EventQueue &m_input;
-            InUDP &m_udp;
-            InOutNetwork &m_tcp;
+            OrderBook::EventQueue m_input;
 
-            uint64_t m_id = 0;
+            InUDP &m_udp_output;
+            InOutNetwork &m_tcp_output;
 
             ThreadPool<TS_SIZE_OE> m_tp;
     };

--- a/server/include/Server/Core/Pipeline/OBEvent.hpp
+++ b/server/include/Server/Core/Pipeline/OBEvent.hpp
@@ -18,7 +18,7 @@ namespace pip
             OBEvent(const std::string &_name, InUDP &_udp, InOutNetwork &_tcp);
             virtual ~OBEvent() = default;
 
-            [[nodiscard]] InputType &getInput();
+            [[nodiscard]] QueueInputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
@@ -30,7 +30,7 @@ namespace pip
         private:
             const std::string m_name;
 
-            OrderBook::EventQueue m_input;
+            QueueInputType m_input;
 
             InUDP &m_udp_output;
             InOutNetwork &m_tcp_output;

--- a/server/include/Server/Core/Pipeline/OutNetwork.hpp
+++ b/server/include/Server/Core/Pipeline/OutNetwork.hpp
@@ -13,24 +13,22 @@ namespace pip
     /// @brief Pipeline to send reply to a client over TCP network.
     template<class Func>
     requires IsProcessor<Func, Context<OutNetworkInput> &>
-    class OutNetwork : public IProcessUnit
+    class OutNetwork : public IProcessUnit<Context<OutNetworkInput>>
     {
         public:
             /// @brief Socket format used
             using Client = net::Acceptor<net::tcp::Socket>::Client;
 
-            /// @brief Construct the pipeline.
-            /// @param _input Input data queue.
-            /// @param _clients List of the connected client.
-            OutNetwork(InOutNetwork &_input);
-            /// @brief Stop and then destroy the pipeline.
+            OutNetwork() = default;
             virtual ~OutNetwork() = default;
+
+            [[nodiscard]] QueueInputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
 
         private:
-            InOutNetwork &m_input;                       ///< Intput data queue.
+            QueueInputType m_input;                       ///< Intput data queue.
 
             ThreadPool<TS_SIZE_ON> m_tp;        ///< Thread pool used to send data to the target client in an other thread.
     };

--- a/server/include/Server/Core/Pipeline/OutNetwork.hpp
+++ b/server/include/Server/Core/Pipeline/OutNetwork.hpp
@@ -12,7 +12,7 @@ namespace pip
 {
     /// @brief Pipeline to send reply to a client over TCP network.
     template<class Func>
-    requires IsProcessor<Func, OutNetworkInput &>
+    requires IsProcessor<Func, Context<OutNetworkInput> &>
     class OutNetwork : public IProcessUnit
     {
         public:

--- a/server/include/Server/Core/Pipeline/OutNetwork.inl
+++ b/server/include/Server/Core/Pipeline/OutNetwork.inl
@@ -6,17 +6,17 @@
 namespace pip
 {
     template<class Func>
-    requires IsProcessor<Func, OutNetworkInput &>
+    requires IsProcessor<Func, Context<OutNetworkInput> &>
     OutNetwork<Func>::OutNetwork(InOutNetwork &_input)
         : m_input(_input)
     {
     }
 
     template<class Func>
-    requires IsProcessor<Func, OutNetworkInput &>
+    requires IsProcessor<Func, Context<OutNetworkInput> &>
     void OutNetwork<Func>::runtime(std::stop_token _st)
     {
-        OutNetworkInput input;
+        Context<OutNetworkInput> input;
 
         while (!_st.stop_requested()) {
             if (!this->m_input.empty()) {

--- a/server/include/Server/Core/Pipeline/OutNetwork.inl
+++ b/server/include/Server/Core/Pipeline/OutNetwork.inl
@@ -7,9 +7,9 @@ namespace pip
 {
     template<class Func>
     requires IsProcessor<Func, Context<OutNetworkInput> &>
-    OutNetwork<Func>::OutNetwork(InOutNetwork &_input)
-        : m_input(_input)
+    OutNetwork<Func>::QueueInputType &OutNetwork<Func>::getInput()
     {
+        return m_input;
     }
 
     template<class Func>

--- a/server/include/Server/Core/Pipeline/Router.hpp
+++ b/server/include/Server/Core/Pipeline/Router.hpp
@@ -6,7 +6,7 @@
 namespace pip
 {
     /// @brief Pipeline running action depending on received message.
-    class Router : public IProcessUnit
+    class Router : public IProcessUnit<Context<RouterInput>>
     {
         public:
             /// @brief Core pipeline type.
@@ -14,10 +14,12 @@ namespace pip
             /// @param _input Input data queue of the pipeline.
             /// @param _output Output data queue of the pipeline.
             /// @param _raw Raw message queue send to the pip::OutNetwork pipeline.
-            Router(InputRouter &_input, InMarketData &_data, InOutNetwork &_raw);
+            Router(InOutNetwork &_raw);
             virtual ~Router() = default;
 
             void registerMarket(const std::string &_name, InMarket &_input);
+
+            InputType &getInput();
 
         protected:
             /// @brief Core function of the pipeline determining it's behavior
@@ -36,8 +38,7 @@ namespace pip
         private:
             MarketEntry m_market_input;      ///< Map of every market ouput data queue.
 
-            InputRouter &m_input;       ///< Intput data queue.
-            InMarketData &m_q_data;      ///< Map of every market ouput data queue.
+            InputRouter m_input;       ///< Intput data queue.
             InOutNetwork &m_tcp_output;           ///< Raw message queue.
     };
 }

--- a/server/include/Server/Core/Pipeline/Router.hpp
+++ b/server/include/Server/Core/Pipeline/Router.hpp
@@ -9,17 +9,12 @@ namespace pip
     class Router : public IProcessUnit<Context<RouterInput>>
     {
         public:
-            /// @brief Core pipeline type.
-            /// @brief Construct the pipeline.
-            /// @param _input Input data queue of the pipeline.
-            /// @param _output Output data queue of the pipeline.
-            /// @param _raw Raw message queue send to the pip::OutNetwork pipeline.
             Router(InOutNetwork &_raw);
             virtual ~Router() = default;
 
             void registerMarket(const std::string &_name, InMarket &_input);
 
-            InputType &getInput();
+            [[nodiscard]] QueueInputType &getInput();
 
         protected:
             /// @brief Core function of the pipeline determining it's behavior
@@ -38,7 +33,7 @@ namespace pip
         private:
             MarketEntry m_market_input;      ///< Map of every market ouput data queue.
 
-            InputRouter m_input;       ///< Intput data queue.
+            QueueInputType m_input;       ///< Intput data queue.
             InOutNetwork &m_tcp_output;           ///< Raw message queue.
     };
 }

--- a/server/include/Server/Core/Pipeline/Router.hpp
+++ b/server/include/Server/Core/Pipeline/Router.hpp
@@ -24,14 +24,14 @@ namespace pip
             void runtime(std::stop_token _st);
 
         protected:
-            bool treatLogon(RouterInput &_input);
-            bool treatLogout(RouterInput &_input);
-            bool treatNewOrderSingle(RouterInput &_input);
-            bool treatOrderCancelRequest(RouterInput &_input);
-            bool treatOrderCancelReplaceRequest(RouterInput &_input);
-            bool treatUnknown(RouterInput &_input);
-            bool treatHeartbeat(RouterInput &_input);
-            bool treatMarketDataRequest(RouterInput &_input);
+            bool treatLogon(Context<RouterInput> &_input);
+            bool treatLogout(Context<RouterInput> &_input);
+            bool treatNewOrderSingle(Context<RouterInput> &_input);
+            bool treatOrderCancelRequest(Context<RouterInput> &_input);
+            bool treatOrderCancelReplaceRequest(Context<RouterInput> &_input);
+            bool treatUnknown(Context<RouterInput> &_input);
+            bool treatHeartbeat(Context<RouterInput> &_input);
+            bool treatMarketDataRequest(Context<RouterInput> &_input);
 
         private:
             MarketEntry m_market_input;      ///< Map of every market ouput data queue.

--- a/server/include/Server/Core/Pipeline/UDPOutNetwork.hpp
+++ b/server/include/Server/Core/Pipeline/UDPOutNetwork.hpp
@@ -19,13 +19,15 @@
 
 namespace pip
 {
-    class UDPOutNetwork : public IProcessUnit
+    class UDPOutNetwork : public IProcessUnit<data::UDPPackage>
     {
         public:
             /// @brief Construct the pipeline.
             /// @param _input Input data queue.
-            UDPOutNetwork(InUDP &_input, uint32_t _port);
+            UDPOutNetwork(uint32_t _port);
             virtual ~UDPOutNetwork() = default;
+
+            [[nodiscard]] QueueInputType &getInput();
 
         protected:
             void runtime(std::stop_token _st);
@@ -39,6 +41,6 @@ namespace pip
 
             net::udp::Socket m_socket;
 
-            InUDP &m_input;
+            QueueInputType m_input;
     };
 }

--- a/server/include/Server/Network/Processor.hpp
+++ b/server/include/Server/Network/Processor.hpp
@@ -19,19 +19,7 @@ namespace net::tcp
 
     namespace out
     {
-
-        // namespace priv
-        // {
-        //     void LogTiming(ClientStore::Client _client);
-        // }
-
         class Response
-        {
-            public:
-                static bool run(Context<OutNetworkInput> &_input);
-        };
-
-        class SubResponse
         {
             public:
                 static bool run(Context<OutNetworkInput> &_input);

--- a/server/include/Server/Network/Processor.hpp
+++ b/server/include/Server/Network/Processor.hpp
@@ -13,7 +13,7 @@ namespace net::tcp
         class Basic
         {
             public:
-                static bool run(ClientStore::Client _client, InputRouter &_serial, InOutNetwork &_error);
+                static bool run(const ClientStore::Client &_client, InputRouter &_serial, InOutNetwork &_error);
         };
     }
 
@@ -28,13 +28,13 @@ namespace net::tcp
         class Response
         {
             public:
-                static bool run(OutNetworkInput &_input);
+                static bool run(Context<OutNetworkInput> &_input);
         };
 
         class SubResponse
         {
             public:
-                static bool run(OutNetworkInput &_input);
+                static bool run(Context<OutNetworkInput> &_input);
         };
     }
 }

--- a/server/src/Core/Core.cpp
+++ b/server/src/Core/Core.cpp
@@ -1,13 +1,11 @@
-#include <iostream>
-
 #include "Common/Core/Logger.hpp"
 #include "Server/Core/Core.hpp"
 
 Core::Core(uint32_t _tcp_port, uint32_t _udp_port)
-    : m_tcp_output("Standard TCP Output", m_q_tcp),
-    m_udp_output("UDP broadcast", _udp_port)
+    : m_tcp_output("Standard TCP Output"),
+    m_udp_output("UDP broadcast", _udp_port),
     m_router("Router", m_tcp_output.getInput()),
-    m_tcp_input("Input Network", m_router.getInput(), m_tcp_output.getInput(), _tcp_port),
+    m_tcp_input("Input Network", m_router.getInput(), m_tcp_output.getInput(), _tcp_port)
 {
     market_init();
 }
@@ -27,11 +25,11 @@ bool Core::start()
     {
         try {
             m_udp_output.status();
-            m_tcp_input.status();
-            for (auto &[_, _pip] : m_markets)
-                _pip.status();
-            m_router.status();
             m_tcp_output.status();
+            for (auto &[_, _pip] : m_markets)
+            _pip.status();
+            m_router.status();
+            m_tcp_input.status();
         } catch (std::future_error &_e) {
             Logger::Log("Pipeline have crash: ", _e.what(), "\n\t> with the code: ", _e.code());
             break;

--- a/server/src/Core/Core.cpp
+++ b/server/src/Core/Core.cpp
@@ -4,12 +4,10 @@
 #include "Server/Core/Core.hpp"
 
 Core::Core(uint32_t _tcp_port, uint32_t _udp_port)
-    : m_innet("Input Network", m_q_router, m_q_tcp, _tcp_port),
-    m_router("Router", m_q_router, m_q_data, m_q_tcp),
-    m_data("Data Handler", m_markets, m_q_data, m_q_repdata),
-    m_outnet("Standard TCP Output", m_q_tcp),
-    m_outdata("Subscribe TCP Output", m_q_repdata),
-    m_udp("UDP broadcast", m_q_udp, _udp_port)
+    : m_tcp_output("Standard TCP Output", m_q_tcp),
+    m_udp_output("UDP broadcast", _udp_port)
+    m_router("Router", m_tcp_output.getInput()),
+    m_tcp_input("Input Network", m_router.getInput(), m_tcp_output.getInput(), _tcp_port),
 {
     market_init();
 }
@@ -28,14 +26,12 @@ bool Core::start()
     while (m_running)
     {
         try {
-            m_udp.status();
-            m_innet.status();
-            // for (auto &[_, _pip] : m_markets)
-            //     _pip.status();
+            m_udp_output.status();
+            m_tcp_input.status();
+            for (auto &[_, _pip] : m_markets)
+                _pip.status();
             m_router.status();
-            m_data.status();
-            m_outdata.status();
-            m_outnet.status();
+            m_tcp_output.status();
         } catch (std::future_error &_e) {
             Logger::Log("Pipeline have crash: ", _e.what(), "\n\t> with the code: ", _e.code());
             break;
@@ -53,20 +49,18 @@ void Core::stop()
     if (m_running) {
         m_running = false;
         Logger::Log("Stoping...");
-        m_innet.stop();
-        Logger::Log(m_innet.getName(), " PU stoped");
+        m_tcp_input.stop();
+        Logger::Log(m_tcp_input.getName(), " PU stoped");
         m_router.stop();
         Logger::Log(m_router.getName(), " PU stoped");
-        m_data.stop();
-        Logger::Log(m_data.getName(), " PU stoped");
         for (auto &[_name, _pip] : m_markets) {
             _pip.stop();
            Logger::Log(_pip.getName(), " PU stoped");
         }
-        m_outnet.stop();
-        Logger::Log(m_outnet.getName(), " PU stoped");
-        m_udp.stop();
-        Logger::Log(m_udp.getName(), " PU stoped");
+        m_tcp_output.stop();
+        Logger::Log(m_tcp_output.getName(), " PU stoped");
+        m_udp_output.stop();
+        Logger::Log(m_udp_output.getName(), " PU stoped");
         Logger::Log("All process unit are stoped");
     }
 }
@@ -74,23 +68,19 @@ void Core::stop()
 bool Core::internal_start()
 {
     Logger::Log("Starting pipeline...");
-    m_udp.start();
-    Logger::Log(m_udp.getName(), " PU started");
-    m_outnet.start();
-    Logger::Log(m_outnet.getName(), " PU started");
-    m_outdata.start();
-    Logger::Log(m_outdata.getName(), " PU started");
+    m_udp_output.start();
+    Logger::Log(m_udp_output.getName(), " PU started");
+    m_tcp_output.start();
+    Logger::Log(m_tcp_output.getName(), " PU started");
 
     for (auto &[_name, _pip] : m_markets) {
         _pip.start();
         Logger::Log(_pip.getName(), " (", _name, ") PU started");
     }
-    m_data.start();
-    Logger::Log(m_data.getName(), " PU started");
     m_router.start();
     Logger::Log(m_router.getName(), " PU started");
-    m_innet.start();
-    Logger::Log(m_innet.getName(), " PU started");
+    m_tcp_input.start();
+    Logger::Log(m_tcp_input.getName(), " PU started");
     return false;
 }
 
@@ -102,7 +92,7 @@ void Core::market_init()
     for (std::string &_name : name) {
         m_markets.emplace(std::piecewise_construct,
             std::forward_as_tuple(_name),
-            std::forward_as_tuple("Market " + _name, _name, m_q_udp, m_q_tcp));
+            std::forward_as_tuple("Market " + _name, _name, m_udp_output.getInput(), m_tcp_output.getInput()));
 
         m_router.registerMarket(_name, m_markets.at(_name).getInput());
     }

--- a/server/src/Core/InternalClient.cpp
+++ b/server/src/Core/InternalClient.cpp
@@ -35,7 +35,7 @@ void InternalClient::shouldDisconnect(bool _disconnect)
     m_should_dc = _disconnect;
 }
 
-bool InternalClient::shouldDisconnect()
+bool InternalClient::shouldDisconnect() const
 {
     return m_should_dc;
 }

--- a/server/src/Core/OrderBook.cpp
+++ b/server/src/Core/OrderBook.cpp
@@ -94,6 +94,11 @@ bool OrderBook::contain(OrderType _type, Price _price)
     return m_bid.contains(_price);
 }
 
+std::string OrderBook::getSymbol() const
+{
+    return m_name;
+}
+
 void OrderBook::add(OrderType _type, Price _price, Order &_order, OrderStatus _status)
 {
     Event event;

--- a/server/src/Core/OrderBook.cpp
+++ b/server/src/Core/OrderBook.cpp
@@ -94,7 +94,7 @@ bool OrderBook::contain(OrderType _type, Price _price)
     return m_bid.contains(_price);
 }
 
-std::string OrderBook::getSymbol() const
+const std::string &OrderBook::getSymbol() const
 {
     return m_name;
 }

--- a/server/src/Core/Pipeline/DataRefresh.cpp
+++ b/server/src/Core/Pipeline/DataRefresh.cpp
@@ -10,7 +10,7 @@ namespace pip
     void DataRefresh::runtime(std::stop_token _st)
     {
         Logger::SetThreadName(THIS_THREAD_ID, "DataRefresh");
-        MarketDataInput input;
+        Context<MarketDataInput> input;
 
         while (!_st.stop_requested()) {
             if (!m_input.empty()) {
@@ -20,7 +20,7 @@ namespace pip
         }
     }
 
-    void DataRefresh::process(MarketDataInput &_input)
+    void DataRefresh::process(Context<MarketDataInput> &_input)
     {
         if (_input.SubType == 0) {
             Logger::Log("[DataRefresh] SubType is refresh");
@@ -38,7 +38,7 @@ namespace pip
                 }
                 m_markets.at(_sym).cache_flush();
                 message.set55_symbol(_sym);
-                m_output.append(std::move(_input.Client), std::move(message));
+                m_output.append(_input.Client, _input.ReceiveTime, std::move(message));
             }
             Logger::Log("[DataRefresh] Refresh done");
         } else if (_input.SubType == 1) {
@@ -60,7 +60,7 @@ namespace pip
                 message.set262_mDReqID(_input.Id);
                 message += m_markets.at(_sym).refresh(sub);
                 // std::cout << "subcribtion size after: " << _input.Client.subscribe(_sym).size() << std::endl;
-                m_output.append(std::move(_input.Client), std::move(message));
+                m_output.append(_input.Client, _input.ReceiveTime, std::move(message));
             }
         } else {
             Logger::Log("[DataRefresh] SubType is unsubscribe");

--- a/server/src/Core/Pipeline/DataRefresh.cpp
+++ b/server/src/Core/Pipeline/DataRefresh.cpp
@@ -2,15 +2,15 @@
 
 namespace pip
 {
-    DataRefresh::DataRefresh(std::map<std::string, ProcessUnit<MarketContainer>> &_markets, InMarketData &_input, InOutNetwork &_output)
-        : m_markets(_markets), m_input(_input), m_output(_output)
+    DataRefresh::DataRefresh(OrderBook &_ob, InOutNetwork &_output)
+        : m_ob(_ob), m_input(_input), m_tcp_output(_output)
     {
     }
 
     void DataRefresh::runtime(std::stop_token _st)
     {
         Logger::SetThreadName(THIS_THREAD_ID, "DataRefresh");
-        Context<MarketDataInput> input;
+        Context<MarketInput> input;
 
         while (!_st.stop_requested()) {
             if (!m_input.empty()) {
@@ -20,58 +20,52 @@ namespace pip
         }
     }
 
-    void DataRefresh::process(Context<MarketDataInput> &_input)
+    void DataRefresh::process(Context<MarketInput> &_input)
     {
-        if (_input.SubType == 0) {
+        if (_input.RefreshData.SubType == 0) {
             Logger::Log("[DataRefresh] SubType is refresh");
             OrderBook::Subscription sub;
             fix::MarketDataSnapshotFullRefresh message;
 
-            message.set262_mDReqID(_input.Id);
-            for (const auto &_sym : _input.Symbols) {
-                Logger::Log("[DataRefresh] Checking for symbol: ", _sym);
-                for (OrderType _type : _input.Types) {
-                    Logger::Log("[DataRefresh] Checking symbol: ", _sym, ", for type: ", (int)_type);
-                    sub.depth = _input.Depth;
-                    sub.type = _type;
-                    message += m_markets.at(_sym).refresh(sub);
-                }
-                m_markets.at(_sym).cache_flush();
-                message.set55_symbol(_sym);
-                m_output.append(_input.Client, _input.ReceiveTime, std::move(message));
+            message.set262_mDReqID(_input.RefreshData.Id);
+            Logger::Log("[DataRefresh] Checking for symbol: ", m_ob.getSymbol());
+            for (OrderType _type : _input.RefreshData.Types) {
+                Logger::Log("[DataRefresh] Checking symbol: ", m_ob.getSymbol(), ", for type: ", (int)_type);
+                sub.depth = _input.RefreshData.Depth;
+                sub.type = _type;
+                message += m_ob.refresh(sub);
             }
+            m_ob.cache_flush();
+            message.set55_symbol(m_ob.getSymbol());
+            m_tcp_output.append(_input.Client, _input.ReceiveTime, std::move(message));
             Logger::Log("[DataRefresh] Refresh done");
-        } else if (_input.SubType == 1) {
+        } else if (_input.RefreshData.SubType == 1) {
             Logger::Log("[DataRefresh] SubType is subscribe");
             OrderBook::Subscription sub;
 
-            sub.depth = _input.Depth;
-            sub.Id = _input.Id;
-            for (const auto &_sym : _input.Symbols) {
-                std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(_sym);
-                fix::MarketDataSnapshotFullRefresh message;
+            sub.depth = _input.RefreshData.Depth;
+            sub.Id = _input.RefreshData.Id;
+            std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(m_ob.getSymbol());
+            fix::MarketDataSnapshotFullRefresh message;
 
-                for (OrderType _type : _input.Types) {
-                    Logger::Log("[DataRefresh] (Subscribe) to: ", _sym, " with type: ", _type);
-                    sub.type = _type;
-                    subs.push_back(sub);
-                }
-                message.set55_symbol(_sym);
-                message.set262_mDReqID(_input.Id);
-                message += m_markets.at(_sym).refresh(sub);
-                // std::cout << "subcribtion size after: " << _input.Client.subscribe(_sym).size() << std::endl;
-                m_output.append(_input.Client, _input.ReceiveTime, std::move(message));
+            for (OrderType _type : _input.RefreshData.Types) {
+                Logger::Log("[DataRefresh] (Subscribe) to: ", m_ob.getSymbol(), " with type: ", _type);
+                sub.type = _type;
+                subs.push_back(sub);
             }
+            message.set55_symbol(m_ob.getSymbol());
+            message.set262_mDReqID(_input.RefreshData.Id);
+            message += m_ob.refresh(sub);
+            // std::cout << "subcribtion size after: " << _input.RefreshData.Client.subscribe(_sym).size() << std::endl;
+            m_tcp_output.append(_input.Client, _input.ReceiveTime, std::move(message));
         } else {
             Logger::Log("[DataRefresh] SubType is unsubscribe");
-            for (const auto &_sym : _input.Symbols) {
-                std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(_sym);
+            std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(m_ob.getSymbol());
 
-                for (OrderType _type : _input.Types)
-                    for (std::vector<OrderBook::Subscription>::iterator it = subs.begin(); it != subs.end();)
-                        if (_input.Id == it->Id && _type == it->type)
-                            subs.erase(it);
-            }
+            for (OrderType _type : _input.RefreshData.Types)
+                for (std::vector<OrderBook::Subscription>::iterator it = subs.begin(); it != subs.end();)
+                    if (_input.RefreshData.Id == it->Id && _type == it->type)
+                        subs.erase(it);
             // what to send???
         }
     }

--- a/server/src/Core/Pipeline/DataRefresh.cpp
+++ b/server/src/Core/Pipeline/DataRefresh.cpp
@@ -3,8 +3,13 @@
 namespace pip
 {
     DataRefresh::DataRefresh(OrderBook &_ob, InOutNetwork &_output)
-        : m_ob(_ob), m_input(_input), m_tcp_output(_output)
+        : m_ob(_ob), m_tcp_output(_output)
     {
+    }
+
+    DataRefresh::QueueInputType &DataRefresh::getInput()
+    {
+        return m_input;
     }
 
     void DataRefresh::runtime(std::stop_token _st)

--- a/server/src/Core/Pipeline/DataRefresh.cpp
+++ b/server/src/Core/Pipeline/DataRefresh.cpp
@@ -27,16 +27,18 @@ namespace pip
 
     void DataRefresh::process(Context<MarketInput> &_input)
     {
-        if (_input.RefreshData.SubType == 0) {
+        MarketRefreshInputData &data = std::get<MarketRefreshInputData>(_input.Data);
+
+        if (data.SubType == 0) {
             Logger::Log("[DataRefresh] SubType is refresh");
             OrderBook::Subscription sub;
             fix::MarketDataSnapshotFullRefresh message;
 
-            message.set262_mDReqID(_input.RefreshData.Id);
+            message.set262_mDReqID(data.Id);
             Logger::Log("[DataRefresh] Checking for symbol: ", m_ob.getSymbol());
-            for (OrderType _type : _input.RefreshData.Types) {
+            for (OrderType _type : data.Types) {
                 Logger::Log("[DataRefresh] Checking symbol: ", m_ob.getSymbol(), ", for type: ", (int)_type);
-                sub.depth = _input.RefreshData.Depth;
+                sub.depth = data.Depth;
                 sub.type = _type;
                 message += m_ob.refresh(sub);
             }
@@ -44,32 +46,32 @@ namespace pip
             message.set55_symbol(m_ob.getSymbol());
             m_tcp_output.append(_input.Client, _input.ReceiveTime, std::move(message));
             Logger::Log("[DataRefresh] Refresh done");
-        } else if (_input.RefreshData.SubType == 1) {
+        } else if (data.SubType == 1) {
             Logger::Log("[DataRefresh] SubType is subscribe");
             OrderBook::Subscription sub;
 
-            sub.depth = _input.RefreshData.Depth;
-            sub.Id = _input.RefreshData.Id;
+            sub.depth = data.Depth;
+            sub.Id = data.Id;
             std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(m_ob.getSymbol());
             fix::MarketDataSnapshotFullRefresh message;
 
-            for (OrderType _type : _input.RefreshData.Types) {
+            for (OrderType _type : data.Types) {
                 Logger::Log("[DataRefresh] (Subscribe) to: ", m_ob.getSymbol(), " with type: ", _type);
                 sub.type = _type;
                 subs.push_back(sub);
             }
             message.set55_symbol(m_ob.getSymbol());
-            message.set262_mDReqID(_input.RefreshData.Id);
+            message.set262_mDReqID(data.Id);
             message += m_ob.refresh(sub);
-            // std::cout << "subcribtion size after: " << _input.RefreshData.Client.subscribe(_sym).size() << std::endl;
+            // std::cout << "subcribtion size after: " << data.Client.subscribe(_sym).size() << std::endl;
             m_tcp_output.append(_input.Client, _input.ReceiveTime, std::move(message));
         } else {
             Logger::Log("[DataRefresh] SubType is unsubscribe");
             std::vector<OrderBook::Subscription> &subs = _input.Client->subscribe(m_ob.getSymbol());
 
-            for (OrderType _type : _input.RefreshData.Types)
+            for (OrderType _type : data.Types)
                 for (std::vector<OrderBook::Subscription>::iterator it = subs.begin(); it != subs.end();)
-                    if (_input.RefreshData.Id == it->Id && _type == it->type)
+                    if (data.Id == it->Id && _type == it->type)
                         subs.erase(it);
             // what to send???
         }

--- a/server/src/Core/Pipeline/Market.cpp
+++ b/server/src/Core/Pipeline/Market.cpp
@@ -34,7 +34,7 @@ namespace pip
     {
         Logger::Log("[Market] Processing new action: ", _data.Client->getUserId());
 
-        switch (_data.OrderData.action) {
+        switch (std::get<OrderBook::Data>(_data.Data).action) {
             case OrderBook::Data::Action::Add:
                 m_tp.enqueue([this, data = std::move(_data)] () mutable {
                     runAdd(data);
@@ -59,71 +59,74 @@ namespace pip
     bool Market::runAdd(const Context<MarketInput> &_data)
     {
         fix::ExecutionReport report;
-        Order order = _data.OrderData.order;
+        const OrderBook::Data &data = std::get<OrderBook::Data>(_data.Data);
+        Order order = data.order;
 
-        Logger::Log("[Market] (New) request: ", _data.OrderData.order); // todo log
-        if (!m_ob.add(_data.OrderData.type, _data.OrderData.price, order)) {
-            Logger::Log("[Market] (New) Reject: Order ID already used: ", _data.OrderData.order.orderId);
+        Logger::Log("[Market] (New) request: ", data.order); // todo log
+        if (!m_ob.add(data.type, data.price, order)) {
+            Logger::Log("[Market] (New) Reject: Order ID already used: ", data.order.orderId);
             report.set14_cumQty("0");
             report.set17_execID();
             report.set20_execTransType("1");
-            report.set37_orderID(_data.OrderData.order.orderId);
-            report.set38_orderQty(std::to_string(_data.OrderData.order.quantity));
+            report.set37_orderID(data.order.orderId);
+            report.set38_orderQty(std::to_string(data.order.quantity));
             report.set39_ordStatus("8");
             report.set40_ordType("2");
-            report.set44_price(std::to_string(_data.OrderData.price));
-            report.set54_side((_data.OrderData.type == OrderType::Ask) ? "4" : "3");
+            report.set44_price(std::to_string(data.price));
+            report.set54_side((data.type == OrderType::Ask) ? "4" : "3");
             report.set58_text("Order Id already used");
             report.set151_leavesQty("0");
             m_tcp_output.append(_data.Client, _data.ReceiveTime, std::move(report));
             return false;
         }
-        Logger::Log("[Market] (New) Order executaded sucefully: ", order, ", price: ", _data.OrderData.price);
+        Logger::Log("[Market] (New) Order executaded sucefully: ", order, ", price: ", data.price);
         return true;
     }
 
     bool Market::runModify(const Context<MarketInput> &_data)
     {
         fix::OrderCancelReject report;
-        Order order = _data.OrderData.order;
+        const OrderBook::Data &data = std::get<OrderBook::Data>(_data.Data);
+        Order order = data.order;
 
         Logger::Log("[Market] (Modify) Request: "); // todo log
-        report.set37_orderID(_data.OrderData.target);
-        report.set11_clOrdID(_data.OrderData.target);
-        report.set41_origClOrdID(_data.OrderData.order.orderId);
-        if (!m_ob.cancel(_data.OrderData.type, _data.OrderData.target, false)) {
+        report.set37_orderID(data.target);
+        report.set11_clOrdID(data.target);
+        report.set41_origClOrdID(data.order.orderId);
+        if (!m_ob.cancel(data.type, data.target, false)) {
             report.set39_ordStatus("8");
             report.set58_text("Order ID doesn't exist");
-            Logger::Log("[Market] (Modify-Cancel) Reject: Order ID already exist: ", _data.OrderData.target);
+            Logger::Log("[Market] (Modify-Cancel) Reject: Order ID already exist: ", data.target);
             m_tcp_output.append(_data.Client, _data.ReceiveTime, std::move(report));
             return false;
-        } else if (!m_ob.modify(_data.OrderData.type, _data.OrderData.price, order)) {
+        } else if (!m_ob.modify(data.type, data.price, order)) {
             report.set39_ordStatus("4");
             report.set58_text("Order ID already exist, target got canceled");
-            Logger::Log("[Market] (Modify-Add) Reject: Order ID already exist: ", _data.OrderData.order.orderId);
+            Logger::Log("[Market] (Modify-Add) Reject: Order ID already exist: ", data.order.orderId);
             m_tcp_output.append(_data.Client, _data.ReceiveTime, std::move(report));
             return false;
         }
-        Logger::Log("[Market] (Modify) Order modify sucessfully: ", _data.OrderData.target, " -> ", order);
+        Logger::Log("[Market] (Modify) Order modify sucessfully: ", data.target, " -> ", order);
         return true;
     }
 
     bool Market::runCancel(const Context<MarketInput> &_data)
     {
         fix::OrderCancelReject report;
+        const OrderBook::Data &data = std::get<OrderBook::Data>(_data.Data);
 
-        Logger::Log("[Market] (Cancel) Request: ", _data.OrderData.order.orderId);
-        if (!m_ob.cancel(_data.OrderData.type, _data.OrderData.order.orderId)) {
-            Logger::Log("[Market] (Cancel) Reject: Order ID not found: ", _data.OrderData.order.orderId);
-            report.set11_clOrdID(_data.OrderData.order.orderId);
-            report.set37_orderID(_data.OrderData.order.orderId);
-            report.set41_origClOrdID(_data.OrderData.order.orderId);
+        Logger::Log("[Market] (Cancel) Request: ", data.order.orderId);
+        if (!m_ob.cancel(data.type, data.order.orderId)) {
+            Logger::Log("[Market] (Cancel) Reject: Order ID not found: ", data.order.orderId);
+            report.set11_clOrdID(data.order.orderId);
+            report.set37_orderID(data.order.orderId);
+            report.set41_origClOrdID(data.order.orderId);
             report.set434_cxlRejReason("8");
             report.set58_text("Order ID doesn't exist");
             m_tcp_output.append(_data.Client, _data.ReceiveTime, std::move(report));
             return false;
         }
-        Logger::Log("[Market] (Cancel) Successfully executed on: ", _data.OrderData.order.orderId);
+        Logger::Log("[Market] (Cancel) Successfully executed on: ", data.order.orderId);
         return true;
     }
 }

--- a/server/src/Core/Pipeline/Market.cpp
+++ b/server/src/Core/Pipeline/Market.cpp
@@ -8,12 +8,12 @@
 
 namespace pip
 {
-    Market::Market(OrderBook &_ob, InMarket &_input, InOutNetwork &_output)
+    Market::Market(OrderBook &_ob, InOutNetwork &_output)
         : m_tcp_output(_output), m_ob(_ob)
     {
     }
 
-    Market::InputType &Market::getInput()
+    Market::QueueInputType &Market::getInput()
     {
         return m_input;
     }

--- a/server/src/Core/Pipeline/Naming.cpp
+++ b/server/src/Core/Pipeline/Naming.cpp
@@ -15,29 +15,39 @@ RouterInput::RouterInput(const fix::Serializer::AnonMessage &&_msg)
 {
 }
 
-RouterInput &RouterInput::operator=(RouterInput &&_data) noexcept
-{
-    if (this != &_data)
-        Message = std::move(_data.Message);
-    return *this;
-}
-
 MarketInput::MarketInput(MarketInput &&_data) noexcept
-    : OrderData(std::move(_data.OrderData))
+    : type(_data.type)
 {
-}
-
-MarketInput::MarketInput(const MarketInput &_data)
-    : OrderData(_data.OrderData)
-{
+    if (type == Type::Order) {
+        OrderData = std::move(_data.OrderData);
+    } else {
+        RefreshData = std::move(_data.RefreshData);
+    }
 }
 
 MarketInput &MarketInput::operator=(MarketInput &&_data) noexcept
 {
-    if (this != &_data)
-        OrderData = std::move(_data.OrderData);
+    if (this != &_data) {
+        type = _data.type;
+        if (type == Type::Order) {
+            OrderData = std::move(_data.OrderData);
+        } else {
+            RefreshData = std::move(_data.RefreshData);
+        }
+    }
     return *this;
 }
+
+MarketInput::MarketInput(const MarketInput &_data)
+    : type(_data.type)
+{
+    if (type == Type::Order) {
+        OrderData = _data.OrderData;
+    } else {
+        RefreshData = _data.RefreshData;
+    }
+}
+
 
 OutNetworkInput::OutNetworkInput(OutNetworkInput &&_data) noexcept
     : Message(std::move(_data.Message))
@@ -58,17 +68,5 @@ OutNetworkInput &OutNetworkInput::operator=(OutNetworkInput &&_data) noexcept
 {
     if (this != &_data)
         Message = std::move(_data.Message);
-    return *this;
-}
-
-MarketDataInput::MarketDataInput(const MarketDataInput &&_data) noexcept
-    : MarketDataInputData(std::move(_data))
-{
-}
-
-MarketDataInput &MarketDataInput::operator=(MarketDataInput &&_data) noexcept
-{
-    if (this != &_data)
-        MarketDataInputData::operator=(std::move(_data));
     return *this;
 }

--- a/server/src/Core/Pipeline/Naming.cpp
+++ b/server/src/Core/Pipeline/Naming.cpp
@@ -1,72 +1,11 @@
 #include "Server/Core/Pipeline/Naming.hpp"
 
-RouterInput::RouterInput(RouterInput &&_data) noexcept
-    : Message(std::move(_data.Message))
-{
-}
-
-RouterInput::RouterInput(const RouterInput &_data)
-    : Message(_data.Message)
-{
-}
-
 RouterInput::RouterInput(const fix::Serializer::AnonMessage &&_msg)
     : Message(std::move(_msg))
-{
-}
-
-MarketInput::MarketInput(MarketInput &&_data) noexcept
-    : type(_data.type)
-{
-    if (type == Type::Order) {
-        OrderData = std::move(_data.OrderData);
-    } else {
-        RefreshData = std::move(_data.RefreshData);
-    }
-}
-
-MarketInput &MarketInput::operator=(MarketInput &&_data) noexcept
-{
-    if (this != &_data) {
-        type = _data.type;
-        if (type == Type::Order) {
-            OrderData = std::move(_data.OrderData);
-        } else {
-            RefreshData = std::move(_data.RefreshData);
-        }
-    }
-    return *this;
-}
-
-MarketInput::MarketInput(const MarketInput &_data)
-    : type(_data.type)
-{
-    if (type == Type::Order) {
-        OrderData = _data.OrderData;
-    } else {
-        RefreshData = _data.RefreshData;
-    }
-}
-
-
-OutNetworkInput::OutNetworkInput(OutNetworkInput &&_data) noexcept
-    : Message(std::move(_data.Message))
-{
-}
-
-OutNetworkInput::OutNetworkInput(const OutNetworkInput &_data)
-    : Message(_data.Message)
 {
 }
 
 OutNetworkInput::OutNetworkInput(const fix::Message &&_msg) noexcept
     : Message(std::move(_msg))
 {
-}
-
-OutNetworkInput &OutNetworkInput::operator=(OutNetworkInput &&_data) noexcept
-{
-    if (this != &_data)
-        Message = std::move(_data.Message);
-    return *this;
 }

--- a/server/src/Core/Pipeline/Naming.cpp
+++ b/server/src/Core/Pipeline/Naming.cpp
@@ -1,92 +1,74 @@
 #include "Server/Core/Pipeline/Naming.hpp"
 
-RouterInput::RouterInput(const RouterInput &&_data) noexcept
-    : Client(std::move(_data.Client)), Message(std::move(_data.Message))
+RouterInput::RouterInput(RouterInput &&_data) noexcept
+    : Message(std::move(_data.Message))
 {
 }
 
-RouterInput::RouterInput(ClientStore::Client _client, const fix::Serializer::AnonMessage &&_msg)
-    : Client(_client), Message(std::move(_msg))
+RouterInput::RouterInput(const RouterInput &_data)
+    : Message(_data.Message)
+{
+}
+
+RouterInput::RouterInput(const fix::Serializer::AnonMessage &&_msg)
+    : Message(std::move(_msg))
 {
 }
 
 RouterInput &RouterInput::operator=(RouterInput &&_data) noexcept
 {
-    if (this != &_data) {
-        Client = std::move(_data.Client);
+    if (this != &_data)
         Message = std::move(_data.Message);
-    }
     return *this;
 }
 
-MarketInput::MarketInput(const MarketInput &&_data) noexcept
-    : Client(std::move(_data.Client)), OrderData(std::move(_data.OrderData))
+MarketInput::MarketInput(MarketInput &&_data) noexcept
+    : OrderData(std::move(_data.OrderData))
 {
 }
 
 MarketInput::MarketInput(const MarketInput &_data)
-    : Client(_data.Client), OrderData(_data.OrderData)
-{
-}
-
-MarketInput::MarketInput(ClientStore::Client _client) noexcept
-    : Client(std::move(_client))
+    : OrderData(_data.OrderData)
 {
 }
 
 MarketInput &MarketInput::operator=(MarketInput &&_data) noexcept
 {
-    if (this != &_data) {
-        Client = std::move(_data.Client);
+    if (this != &_data)
         OrderData = std::move(_data.OrderData);
-    }
     return *this;
 }
 
-OutNetworkInput::OutNetworkInput(const OutNetworkInput &&_data) noexcept
-    : Client(std::move(_data.Client)), Message(std::move(_data.Message))
+OutNetworkInput::OutNetworkInput(OutNetworkInput &&_data) noexcept
+    : Message(std::move(_data.Message))
 {
 }
 
 OutNetworkInput::OutNetworkInput(const OutNetworkInput &_data)
-    : Client(_data.Client), Message(_data.Message)
+    : Message(_data.Message)
 {
 }
 
-OutNetworkInput::OutNetworkInput(ClientStore::Client _client, const fix::Message &&_msg) noexcept
-    : Client(std::move(_client)), Message(std::move(_msg))
-{
-}
-
-OutNetworkInput::OutNetworkInput(ClientStore::Client _client, const fix::Message &_msg)
-    : Client(_client), Message(_msg)
+OutNetworkInput::OutNetworkInput(const fix::Message &&_msg) noexcept
+    : Message(std::move(_msg))
 {
 }
 
 OutNetworkInput &OutNetworkInput::operator=(OutNetworkInput &&_data) noexcept
 {
-    if (this != &_data) {
-        Client = std::move(_data.Client);
+    if (this != &_data)
         Message = std::move(_data.Message);
-    }
     return *this;
 }
 
 MarketDataInput::MarketDataInput(const MarketDataInput &&_data) noexcept
-    : MarketDataInputData(std::move(_data)), Client(std::move(_data.Client))
-{
-}
-
-MarketDataInput::MarketDataInput(ClientStore::Client _client, const MarketDataInputData &&_data) noexcept
-    : MarketDataInputData(std::move(_data)), Client(_client)
+    : MarketDataInputData(std::move(_data))
 {
 }
 
 MarketDataInput &MarketDataInput::operator=(MarketDataInput &&_data) noexcept
 {
-    if (this != &_data) {
+    if (this != &_data)
         MarketDataInputData::operator=(std::move(_data));
-        Client = std::move(_data.Client);
-    }
     return *this;
 }

--- a/server/src/Core/Pipeline/Notification.cpp
+++ b/server/src/Core/Pipeline/Notification.cpp
@@ -29,7 +29,7 @@ namespace pip
                         if (!subs.empty()) {
                             for (const auto &_sub : subs)
                                 notif += m_ob.update(_sub);
-                            m_tcp_output.append(_client, notif);
+                            m_tcp_output.append(_client, std::chrono::system_clock::now(), std::move(notif));
                         }
                     }
                 });

--- a/server/src/Core/Pipeline/Notification.cpp
+++ b/server/src/Core/Pipeline/Notification.cpp
@@ -4,8 +4,8 @@
 
 namespace pip
 {
-    Notification::Notification(const std::string &_name, OrderBook &_ob, InOutNetwork &_tcp)
-        : m_name(_name), m_tcp_output(_tcp), m_ob(_ob)
+    Notification::Notification(OrderBook &_ob, InOutNetwork &_tcp)
+        : m_tcp_output(_tcp), m_ob(_ob)
     {
     }
 
@@ -20,9 +20,9 @@ namespace pip
             if (update_diff.count() >= NOTIF_UPDATE_TO) {
                 Logger::Log("[Refresh] incremenetal - start");
                 ClientStore::Instance().Apply([*this] (ClientStore::Client _client) {
-                    Logger::Log("[Refresh] Looking for subscribtion of ", m_name, " for user: ", _client == nullptr);
-                    if (_client->isSubscribeTo(m_name)) {
-                        const InternalClient::Subs &subs = _client->subscribe(m_name);
+                    Logger::Log("[Refresh] Looking for subscribtion of ", m_ob.getSymbol(), " for user: ", _client == nullptr);
+                    if (_client->isSubscribeTo(m_ob.getSymbol())) {
+                        const InternalClient::Subs &subs = _client->subscribe(m_ob.getSymbol());
                         fix::MarketDataIncrementalRefresh notif;
 
                         Logger::Log("[Refresh] Incremental For client: ", _client->getUserId(), ", size of the query: ", subs.size());

--- a/server/src/Core/Pipeline/OBEvent.cpp
+++ b/server/src/Core/Pipeline/OBEvent.cpp
@@ -11,7 +11,7 @@ namespace pip
     {
     }
 
-    OBEvent::InputType &OBEvent::getInput()
+    OBEvent::QueueInputType &OBEvent::getInput()
     {
         return m_input;
     }

--- a/server/src/Core/Pipeline/OBEvent.cpp
+++ b/server/src/Core/Pipeline/OBEvent.cpp
@@ -6,9 +6,14 @@
 
 namespace pip
 {
-    OBEvent::OBEvent(const std::string &_name, OrderBook::EventQueue &_input, InUDP &_udp, InOutNetwork &_tcp)
-        : m_name(_name), m_input(_input), m_udp(_udp), m_tcp(_tcp)
+    OBEvent::OBEvent(const std::string &_name, InUDP &_udp, InOutNetwork &_tcp)
+        : m_name(_name), m_udp_output(_udp), m_tcp_output(_tcp)
     {
+    }
+
+    OBEvent::InputType &OBEvent::getInput()
+    {
+        return m_input;
     }
 
     void OBEvent::runtime(std::stop_token _st)
@@ -46,13 +51,14 @@ namespace pip
         report.set55_symbol(m_name);
         report.set151_leavesQty(std::to_string(_input.quantity));
         report.set150_execType(std::to_string(static_cast<uint8_t>(_input.status)));
-        m_tcp.append(client, std::chrono::system_clock::now(), std::move(report));
+        m_tcp_output.append(client, std::chrono::system_clock::now(), std::move(report));
         Logger::Log("[OBEvent] (TCP) Report created: "); // todo log
         return true;
     }
 
     bool OBEvent::createUdp(const OrderBook::Event &_input)
     {
+        static uint64_t id = 0;
         data::UDPPackage package;
 
         if (_input.status == OrderStatus::Pending || _input.quantity == 0)
@@ -62,17 +68,19 @@ namespace pip
         package.flag = 0;
         package.quantity = 0;
         package.price = 0;
-        package.id = m_id++;
+        package.id = id++;
         UDP_FLAG_SET_SOLD(package.flag, _input.sold);
         UDP_FLAG_SET_STATUS(package.flag, _input.status);
         (_input.side == OrderType::Ask) ? UDP_FLAG_SET_ASK(package.flag) : UDP_FLAG_SET_BID(package.flag);
         package.quantity = _input.quantity;
         package.price = _input.price;
+
         Logger::Log("[OBEvent] (UDP) Setting Symbol");
         std::memset(package.symbol, '0', std::min(m_name.size(), (size_t)MARKET_NAME_MAX_SIZE));
         std::memcpy(package.symbol, m_name.c_str(), std::min(m_name.size(), (size_t)MARKET_NAME_MAX_SIZE));
+
         Logger::Log("[OBEvent] (UDP) Report created: ", package);
-        m_udp.append(std::move(package));
+        m_udp_output.append(std::move(package));
         return true;
     }
 }

--- a/server/src/Core/Pipeline/OBEvent.cpp
+++ b/server/src/Core/Pipeline/OBEvent.cpp
@@ -46,7 +46,7 @@ namespace pip
         report.set55_symbol(m_name);
         report.set151_leavesQty(std::to_string(_input.quantity));
         report.set150_execType(std::to_string(static_cast<uint8_t>(_input.status)));
-        m_tcp.append(std::move(client), std::move(report));
+        m_tcp.append(client, std::chrono::system_clock::now(), std::move(report));
         Logger::Log("[OBEvent] (TCP) Report created: "); // todo log
         return true;
     }

--- a/server/src/Core/Pipeline/Router.cpp
+++ b/server/src/Core/Pipeline/Router.cpp
@@ -18,7 +18,7 @@ namespace pip
         m_market_input.emplace(_name, _input);
     }
 
-    Router::InputType &Router::getInput()
+    Router::QueueInputType &Router::getInput()
     {
         return m_input;
     }
@@ -269,7 +269,7 @@ namespace pip
                 return false; // build reject
         }
         for (const auto &_sym : symbols)
-            m_market_input[_sym].append(std::move(sub)); // reject if not found
+            m_market_input.at(_sym).append(std::move(sub)); // reject if not found
         Logger::Log("(MarketDataRequest) Validate from client: ", _input.Client->getUserId());
         return true;
     }

--- a/server/src/Core/Pipeline/Router.cpp
+++ b/server/src/Core/Pipeline/Router.cpp
@@ -30,13 +30,11 @@ namespace pip
 
         while (!_st.stop_requested())
         {
-            if (!m_input.empty())
+            while (!m_input.empty())
             {
                 input = m_input.pop_front();
                 reject = fix::Header::Verify(input.Message, input.Client->getUserId(), PROVIDER_NAME, input.Client->getSeqNumber());
                 if (reject.first) {
-                    reject.second.header.set56_TargetCompId(input.Client->getUserId());
-                    reject.second.header.set49_SenderCompId(PROVIDER_NAME);
                     Logger::Log("Header verification failed");
                     m_tcp_output.append(input.Client, input.ReceiveTime, std::move(reject.second));
                     continue;
@@ -131,7 +129,6 @@ namespace pip
         _input.Client->shouldDisconnect(true);
 
         Logger::Log("(Logon) Client set as logged out: (", *(_input.Client), ")");
-        logout.header.set56_TargetCompId(_input.Client->getUserId());
         Logger::Log("(Logout) Reply to (", *(_input.Client), ") moving to TCP output");
         m_tcp_output.append(_input.Client, _input.ReceiveTime, std::move(logout));
         return true;

--- a/server/src/Core/Pipeline/UDPOutNetwork.cpp
+++ b/server/src/Core/Pipeline/UDPOutNetwork.cpp
@@ -5,12 +5,15 @@
 
 namespace pip
 {
-    UDPOutNetwork::UDPOutNetwork(InUDP &_input, uint32_t _port)
-        : m_input(_input)
+    UDPOutNetwork::UDPOutNetwork(uint32_t _port)
     {
-
         if (!m_socket.broadcastOn(_port))
             Logger::Log("[UDPOutNetwork] Failed to setup broadcast, crashing after first action");
+    }
+
+    UDPOutNetwork::QueueInputType &UDPOutNetwork::getInput()
+    {
+        return m_input;
     }
 
     void UDPOutNetwork::runtime(std::stop_token _st)

--- a/server/src/Network/Processor.cpp
+++ b/server/src/Network/Processor.cpp
@@ -52,7 +52,7 @@ namespace net::tcp
                     Logger::Log("[Responce] Data send successfuly: ", data);
                 else
                     Logger::Log("[Responce] Error occured when sending data");
-                // priv::LogTiming(_data.Client);
+                // todo log timing
                 Logger::Log("[Responce] Updated client status: { UserId: ", _data.Client->getUserId(), " }"); // todo log
                 if (_data.Client->shouldDisconnect()) {
                     _data.Client->disconnect();
@@ -63,22 +63,6 @@ namespace net::tcp
                 ClientStore::Instance().removeClient(_data.Client);
                 return true;
             }
-            return false;
-        }
-
-        bool SubResponse::run(Context<OutNetworkInput> &_data)
-        {
-            std::string data{};
-
-            _data.Message.header.set49_SenderCompId(PROVIDER_NAME);
-            _data.Message.header.set34_msgSeqNum(std::to_string(_data.Client->nextSeqNumber()));
-            _data.Message.header.set56_TargetCompId(_data.Client->getUserId());
-            data = _data.Message.to_string();
-            if (_data.Client->getSocket()->send(reinterpret_cast<const uint8_t *>(data.c_str()), data.size()) == data.size())
-                Logger::Log("[Responce] Data send successfuly: ", data);
-            else
-                Logger::Log("[Responce] Error occured when sending data");
-            // priv::LogTiming(_data.Client);
             return false;
         }
     }

--- a/server/src/Network/Processor.cpp
+++ b/server/src/Network/Processor.cpp
@@ -41,10 +41,11 @@ namespace net::tcp
     {
         bool Response::run(Context<OutNetworkInput> &_data)
         {
+            std::string data = _data.Message.to_string();
+
             _data.Message.header.set49_SenderCompId(PROVIDER_NAME);
             _data.Message.header.set34_msgSeqNum(std::to_string(_data.Client->nextSeqNumber()));
             _data.Message.header.set56_TargetCompId(_data.Client->getUserId());
-            std::string data = _data.Message.to_string();
 
             if (_data.Client->getSocket()) { // todo is_open
                 if (_data.Client->getSocket()->send(reinterpret_cast<const uint8_t *>(data.c_str()), data.size()) == data.size())

--- a/server/src/Network/Processor.cpp
+++ b/server/src/Network/Processor.cpp
@@ -41,11 +41,11 @@ namespace net::tcp
     {
         bool Response::run(Context<OutNetworkInput> &_data)
         {
-            std::string data = _data.Message.to_string();
-
-            _data.Message.header.set49_SenderCompId(PROVIDER_NAME);
             _data.Message.header.set34_msgSeqNum(std::to_string(_data.Client->nextSeqNumber()));
+            _data.Message.header.set49_SenderCompId(PROVIDER_NAME);
             _data.Message.header.set56_TargetCompId(_data.Client->getUserId());
+
+            std::string data = _data.Message.to_string();
 
             if (_data.Client->getSocket()) { // todo is_open
                 if (_data.Client->getSocket()->send(reinterpret_cast<const uint8_t *>(data.c_str()), data.size()) == data.size())


### PR DESCRIPTION
- Rename and format transit message using `Context` to store client and time information
- Implementation of input (`getInput`) reference to easier binding between `ProcessUnit`
- Use single TCP output
- Move `DataRefresh` into `MarketContainer` using `std::variant` for routing