### PR TITLE
docs: fix spelling and grammatical errors in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cd FIX4.2-protocol
 
 2. Build with CMake:
 
-To build the client use set the cmake optiona `ClientBuild` to **true** and for the server use `ServerBuild`.
+To build the client use set the cmake option `ClientBuild` to **true** and for the server use `ServerBuild`.
 
 ```bash
 mkdir build
@@ -59,10 +59,10 @@ This project is licensed under the [MIT License](LICENSE)
 
 ---
 
-_Note: This project is a fork of [gabirel1/Epitech-Principe-financier-de-base-et-architecture](https://github.com/gabirel1/Epitech-Principe-financier-de-base-et-architecture) wich has been adapted for educational purposes, but this version is a complete rewrite and aim to be a **PoC** of a server/client_
+_Note: This project is a fork of [gabirel1/Epitech-Principe-financier-de-base-et-architecture](https://github.com/gabirel1/Epitech-Principe-financier-de-base-et-architecture) which has been adapted for educational purposes, but this version is a complete rewrite and aims to be a **PoC** of a server/client_
 
 ---
 
-## Maintenair
+## Maintainer
 
-Maintened by [@DipStax](https://github.com/DipStax)
+Maintained by [@DipStax](https://github.com/DipStax)

--- a/client/back/README.md
+++ b/client/back/README.md
@@ -33,6 +33,4 @@ The Initiator provides the Backend with necessary configuration, including:
 
 - The allowed API key for session validation
 - The Unix socket address for IPC communication with the Initiator
-- The session token for secure synchronization with the Backend
-
-The **Backend** is the core processing engine of the FIX 4.2 protocol client.
+- The session token for secure synchronization with the Frontend

--- a/server/README.md
+++ b/server/README.md
@@ -2,7 +2,7 @@
 
 ## FIX specification
 
-You can find the specification of the supported message and their feild in the [`spec`](./spec/README.md) folder.
+You can find the specification of the supported message and their field in the [`spec`](./spec/README.md) folder.
 This provide a table as:
 
 | Tag | Field Name | Required | Comments |
@@ -12,13 +12,13 @@ This provide a table as:
 - `Tag`: the tag reference by the field.
 - `Field Name`: the name of the field, the link is a reference to the FIX4.2 protocol manual followed by the server (as the title).
 - `Required`: specify if it is required (most of the time it is, because this **PoC**)
-- `Comments`: additionnal comment on the field and what it representes.
+- `Comments`: additional comment on the field and what it represents.
 
 ## Implementation
 
 ### Login
 
-You can login using the [`Logon`](./spec/Logon.md) message, if the login is valid the server will respond with a `Logon` Message that aknowledge the login. A session will be open until you send the `Logout` (see next section) or disconnect the socket.
+You can login using the [`Logon`](./spec/Logon.md) message, if the login is valid the server will respond with a `Logon` Message that acknowledges the login. A session will be open until you send the `Logout` (see next section) or disconnect the socket.
 
 > Currently no verification are done on the `Sender Id`, no database and no in memory verification for duplicate.
 
@@ -45,11 +45,11 @@ Order management includes validation, routing, and matching against the order bo
 
 ### Rejection
 
-Their is 2 available rejection type:
-- [`Buisness`](./spec/BusinessMessageReject.md): reject on message/transaction made at the buisness level (e.g., order book or trading logic errors).
+There are 2 available rejection types:
+- [`Business`](./spec/BusinessMessageReject.md): reject on message/transaction made at the business level (e.g., order book or trading logic errors).
 - [`Standard`](./spec/Reject.md): reject message made at the system level (e.g., logon failures, invalid headers, protocol violations)
 
-> Not all case of rejection are coverade, so if you don't receive a respond after sending a message, consider it to be rejected (the `Message Sequence Number` is not incremented for the reply)
+> Not all cases of rejection are covered, so if you don't receive a response after sending a message, consider it to be rejected (the `Message Sequence Number` is not incremented for the reply)
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
This PR addresses the spelling and grammatical errors identified in the documentation feedback. It improves the overall quality and professionalism of the project documentation.

## Changes Made

### 📝 Main README (`README.md`)
- Fixed typo: `optiona` → `option` (line 47)
- Fixed typo: `wich` → `which` (line 62)
- Fixed typo: `aim` → `aims` (line 62)
- Fixed section heading: `Maintenair` → `Maintainer` (line 66)
- Fixed typo: `Maintened` → `Maintained` (line 68)

### 📝 Server README (`server/README.md`)
- Fixed typo: `feild` → `field` (line 5)
- Fixed typo: `additionnal` → `additional` (line 15)
- Fixed typo: `representes` → `represents` (line 15)
- Fixed typo: `aknowledge` → `acknowledges` (line 21)
- Fixed grammar: `Their is` → `There are` (line 49)
- Fixed typo: `Buisness` → `Business` (line 49)
- Fixed typo: `buisness` → `business` (line 49)
- Fixed typo: `case` → `cases` (line 52)
- Fixed typo: `coverade` → `covered` (line 52)
- Fixed typo: `respond` → `response` (line 52)

### 📝 Backend README (`client/back/README.md`)
- Removed duplicated line at the end of the file
- Fixed incorrect reference: `synchronization with the Backend` → `synchronization with the Frontend`

## Testing
✅ All markdown files render correctly
✅ No broken links introduced
✅ Documentation remains consistent and clear

## Impact
These changes are documentation-only and have no impact on the codebase functionality. They improve:
- Professional appearance of the project
- Clarity for international contributors
- Overall documentation quality

## Related Issues
- Addresses feedback from documentation review regarding documentation quality

## Checklist
- [x] Documentation has been updated
- [x] Spelling and grammar checked
- [x] No functional code changes
- [x] Commit message follows conventional format

---

*This is the first PR focusing on documentation improvements. Future PRs will address code-level issues identified in the feedback.*

🤖 Generated with [Claude Code](https://claude.ai/code)